### PR TITLE
Fix tower defense game code

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -360,6 +360,10 @@ class GameBootstrap {
             
             this.game = new Game(canvas);
             
+            // Publish global references used by various systems
+            window.game = this.game;
+            window.camera = window.camera || new Camera(canvas);
+            
             // Pass the early ScreenManager to the game if available
             if (this.screenManager) {
                 this.game.screenManager = this.screenManager;
@@ -648,8 +652,10 @@ class GameBootstrap {
 document.addEventListener('DOMContentLoaded', () => {
     const bootstrap = new GameBootstrap();
     bootstrap.setupGlobalErrorHandlers();
+    // expose bootstrap early so emergency-fallback can see the initializing flag
+    window.gameBootstrap = bootstrap;
     bootstrap.init();
-    
+
     // Make troubleshooting function globally accessible
     window.GameBootstrap = {
         showTroubleshootingInfo: () => bootstrap.showTroubleshootingInfo(),

--- a/js/pathGenerator.js
+++ b/js/pathGenerator.js
@@ -1264,4 +1264,6 @@ class PathGenerator {
 // Export for use in other modules
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = PathGenerator;
+} else {
+    window.PathGenerator = PathGenerator;
 }


### PR DESCRIPTION
Expose `PathGenerator`, `game`, `camera`, and `gameBootstrap` to the global `window` object to fix game initialization and system dependencies.

Previously, `PathGenerator` was not globally accessible, leading to silent fallback for level path generation. Additionally, `window.camera` was missing, breaking input and rendering, and `window.gameBootstrap` was not exposed early enough, causing the emergency fallback to incorrectly activate.

---
<a href="https://cursor.com/background-agent?bcId=bc-d42c6b29-0383-4c87-9859-6d4003b916a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d42c6b29-0383-4c87-9859-6d4003b916a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

