### PR TITLE
Revamp game page left UI

### DIFF
--- a/css/ui-screens.css
+++ b/css/ui-screens.css
@@ -398,8 +398,6 @@
     font-size: 0.65rem;
     color: #ccc;
     font-weight: 500;
-    text-align: center;
-    margin-bottom: 1px;
 }
 
 .defense-cost {
@@ -453,7 +451,74 @@
     background: rgba(255, 255, 255, 0.2);
 }
 
-/* All other screens hidden by default */
+/* === Left panel clarity and overflow-safe overrides === */
+.left-panel .resource-header,
+.left-panel .resource-display,
+.left-panel .resource-generation {
+    min-width: 0; /* allow flex children to shrink */
+}
+
+.left-panel .resource-display {
+    padding: 0;               /* remove global padding */
+    background: none;         /* remove global background */
+    border: 0;                /* remove global border */
+    box-shadow: none;         /* remove global glow */
+    gap: 4px;
+}
+
+.left-panel .resource-display::before {
+    content: none; /* disable decorative pulse */
+}
+
+.left-panel .resource-value {
+    font-size: 0.8rem;        /* emphasize key values */
+    font-weight: 700;
+}
+
+.left-panel .resource-label,
+.left-panel .resource-generation {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 40%;
+}
+
+.left-panel .resource.enhanced {
+    gap: 4px;
+}
+
+/* Make secondary sections smaller and safe */
+.left-panel .section-title {
+    font-size: 0.6rem;
+}
+
+.left-panel .stat-item {
+    gap: 6px;
+}
+
+.left-panel .stat-item .stat-label,
+.left-panel .stat-item .stat-value {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.left-panel .quote-text {
+    overflow-wrap: anywhere;
+}
+
+.left-panel .lore-item {
+    overflow-wrap: anywhere;
+}
+
+/* Prevent hover enlargement inside compact panel */
+.left-panel .resource-display:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: transparent;
+}
+
 #main-menu-screen,
 #achievement-gallery-screen,
 #settings-screen,


### PR DESCRIPTION
Refine the game page's left panel UI to prevent text overflow, adjust font sizes, and emphasize key game information.

---
<a href="https://cursor.com/background-agent?bcId=bc-56b98abc-bad7-480e-a362-d9a659c5afdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56b98abc-bad7-480e-a362-d9a659c5afdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

