### PR TITLE
Initialize GameBootstrap background progress

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -16,6 +16,7 @@ class GameBootstrap {
         // Initialize managers
         this.loadingScreenManager = new LoadingScreenManager();
         this.progressIndicatorManager = new ProgressIndicatorManager();
+        this.backgroundProgress = this.progressIndicatorManager.backgroundProgress;
         this.assetLoader = new AssetLoader();
         this.errorNotificationManager = new ErrorNotificationManager();
         this.screenManager = new ScreenManager();
@@ -158,7 +159,7 @@ class GameBootstrap {
 
     updateBackgroundProgress(message, stepIndex) {
         if (this.progressIndicatorManager && this.progressIndicatorManager.update) {
-            this.progressIndicatorManager.update(message, stepIndex, this.backgroundProgress.total);
+            this.progressIndicatorManager.update(message, stepIndex);
         }
     }
 


### PR DESCRIPTION
## Summary
- mirror `ProgressIndicatorManager`'s background progress object inside `GameBootstrap`
- simplify `updateBackgroundProgress` to delegate directly to the progress indicator manager

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896c8e6372883278b0fad1554a19773