### PR TITLE
fix: detach event listeners

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -34,7 +34,22 @@ class InputManager {
         this.camera = null;
         this.listeners = new Map();
         this.eventQueue = [];
-        
+
+        // Bind event handlers once so the same references can be removed later
+        this.onMouseDown = this.onMouseDown.bind(this);
+        this.onMouseMove = this.onMouseMove.bind(this);
+        this.onMouseUp = this.onMouseUp.bind(this);
+        this.onMouseLeave = this.onMouseLeave.bind(this);
+        this.onWheel = this.onWheel.bind(this);
+        this.onTouchStart = this.onTouchStart.bind(this);
+        this.onTouchMove = this.onTouchMove.bind(this);
+        this.onTouchEnd = this.onTouchEnd.bind(this);
+        this.onKeyDown = this.onKeyDown.bind(this);
+        this.onKeyUp = this.onKeyUp.bind(this);
+        this.onWindowBlur = this.onWindowBlur.bind(this);
+        this.onWindowFocus = this.onWindowFocus.bind(this);
+        this.onContextMenu = this.onContextMenu.bind(this);
+
         this.setupEventListeners();
     }
 
@@ -54,28 +69,28 @@ class InputManager {
     }
 
     setupEventListeners() {
-        document.addEventListener('keydown', (e) => this.onKeyDown(e));
-        document.addEventListener('keyup', (e) => this.onKeyUp(e));
-        
-        window.addEventListener('blur', () => this.onWindowBlur());
-        window.addEventListener('focus', () => this.onWindowFocus());
+        document.addEventListener('keydown', this.onKeyDown);
+        document.addEventListener('keyup', this.onKeyUp);
+
+        window.addEventListener('blur', this.onWindowBlur);
+        window.addEventListener('focus', this.onWindowFocus);
     }
 
     setupCanvasListeners() {
         if (!this.canvas) return;
 
-        this.canvas.addEventListener('mousedown', (e) => this.onMouseDown(e));
-        this.canvas.addEventListener('mousemove', (e) => this.onMouseMove(e));
-        this.canvas.addEventListener('mouseup', (e) => this.onMouseUp(e));
-        this.canvas.addEventListener('mouseleave', (e) => this.onMouseLeave(e));
-        this.canvas.addEventListener('wheel', (e) => this.onWheel(e));
+        this.canvas.addEventListener('mousedown', this.onMouseDown);
+        this.canvas.addEventListener('mousemove', this.onMouseMove);
+        this.canvas.addEventListener('mouseup', this.onMouseUp);
+        this.canvas.addEventListener('mouseleave', this.onMouseLeave);
+        this.canvas.addEventListener('wheel', this.onWheel);
 
-        this.canvas.addEventListener('touchstart', (e) => this.onTouchStart(e));
-        this.canvas.addEventListener('touchmove', (e) => this.onTouchMove(e));
-        this.canvas.addEventListener('touchend', (e) => this.onTouchEnd(e));
-        this.canvas.addEventListener('touchcancel', (e) => this.onTouchEnd(e));
+        this.canvas.addEventListener('touchstart', this.onTouchStart);
+        this.canvas.addEventListener('touchmove', this.onTouchMove);
+        this.canvas.addEventListener('touchend', this.onTouchEnd);
+        this.canvas.addEventListener('touchcancel', this.onTouchEnd);
 
-        this.canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+        this.canvas.addEventListener('contextmenu', this.onContextMenu);
     }
 
     removeCanvasListeners() {
@@ -90,6 +105,7 @@ class InputManager {
         this.canvas.removeEventListener('touchmove', this.onTouchMove);
         this.canvas.removeEventListener('touchend', this.onTouchEnd);
         this.canvas.removeEventListener('touchcancel', this.onTouchEnd);
+        this.canvas.removeEventListener('contextmenu', this.onContextMenu);
     }
 
     onMouseDown(e) {
@@ -142,13 +158,17 @@ class InputManager {
 
     onWheel(e) {
         e.preventDefault();
-        
+
         this.queueEvent('wheel', {
             x: this.mouse.x,
             y: this.mouse.y,
             deltaY: e.deltaY,
             deltaX: e.deltaX
         });
+    }
+
+    onContextMenu(e) {
+        e.preventDefault();
     }
 
     onTouchStart(e) {

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -24,7 +24,20 @@ class MobileManager {
         // Performance optimization for mobile
         this.isLowPowerMode = false;
         this.reducedQuality = false;
-        
+
+        // Bind handlers so they can be removed properly
+        this.handleTouchStart = this.handleTouchStart.bind(this);
+        this.handleTouchMove = this.handleTouchMove.bind(this);
+        this.handleTouchEnd = this.handleTouchEnd.bind(this);
+        this.handleTouchCancel = this.handleTouchCancel.bind(this);
+        this.preventDefaultTouch = this.preventDefaultTouch.bind(this);
+        this.preventDoubleClick = this.preventDoubleClick.bind(this);
+        this.handleOrientationChange = this.handleOrientationChange.bind(this);
+        this.handleResize = this.handleResize.bind(this);
+        this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
+        this.handleWindowBlur = this.handleWindowBlur.bind(this);
+        this.handleWindowFocus = this.handleWindowFocus.bind(this);
+
         this.detectMobile();
         this.initializeEventListeners();
         this.setupOrientationHandling();
@@ -70,28 +83,28 @@ class MobileManager {
         if (!this.isMobile) return;
         
         // Touch events
-        document.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false });
-        document.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false });
-        document.addEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false });
-        document.addEventListener('touchcancel', this.handleTouchCancel.bind(this), { passive: false });
-        
+        document.addEventListener('touchstart', this.handleTouchStart, { passive: false });
+        document.addEventListener('touchmove', this.handleTouchMove, { passive: false });
+        document.addEventListener('touchend', this.handleTouchEnd, { passive: false });
+        document.addEventListener('touchcancel', this.handleTouchCancel, { passive: false });
+
         // Prevent default touch behaviors
-        document.addEventListener('touchstart', this.preventDefaultTouch.bind(this), { passive: false });
-        document.addEventListener('touchmove', this.preventDefaultTouch.bind(this), { passive: false });
-        
+        document.addEventListener('touchstart', this.preventDefaultTouch, { passive: false });
+        document.addEventListener('touchmove', this.preventDefaultTouch, { passive: false });
+
         // Prevent zoom on double tap
-        document.addEventListener('dblclick', (e) => e.preventDefault());
-        
+        document.addEventListener('dblclick', this.preventDoubleClick);
+
         // Handle device orientation changes
-        window.addEventListener('orientationchange', this.handleOrientationChange.bind(this));
-        window.addEventListener('resize', this.handleResize.bind(this));
-        
+        window.addEventListener('orientationchange', this.handleOrientationChange);
+        window.addEventListener('resize', this.handleResize);
+
         // Handle visibility changes (app backgrounding)
-        document.addEventListener('visibilitychange', this.handleVisibilityChange.bind(this));
-        
+        document.addEventListener('visibilitychange', this.handleVisibilityChange);
+
         // Handle focus/blur for pause on background
-        window.addEventListener('blur', this.handleWindowBlur.bind(this));
-        window.addEventListener('focus', this.handleWindowFocus.bind(this));
+        window.addEventListener('blur', this.handleWindowBlur);
+        window.addEventListener('focus', this.handleWindowFocus);
     }
 
     preventDefaultTouch(event) {
@@ -99,6 +112,10 @@ class MobileManager {
         if (event.target.tagName !== 'INPUT' && event.target.tagName !== 'TEXTAREA') {
             event.preventDefault();
         }
+    }
+
+    preventDoubleClick(e) {
+        e.preventDefault();
     }
 
     handleTouchStart(event) {
@@ -548,6 +565,14 @@ class MobileManager {
         document.removeEventListener('touchmove', this.handleTouchMove);
         document.removeEventListener('touchend', this.handleTouchEnd);
         document.removeEventListener('touchcancel', this.handleTouchCancel);
+        document.removeEventListener('touchstart', this.preventDefaultTouch);
+        document.removeEventListener('touchmove', this.preventDefaultTouch);
+        document.removeEventListener('dblclick', this.preventDoubleClick);
+        window.removeEventListener('orientationchange', this.handleOrientationChange);
+        window.removeEventListener('resize', this.handleResize);
+        document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+        window.removeEventListener('blur', this.handleWindowBlur);
+        window.removeEventListener('focus', this.handleWindowFocus);
         
         // Remove touch controls
         const controlsContainer = document.getElementById('touch-controls');


### PR DESCRIPTION
## Summary
- bind InputManager handlers so canvas, window and document listeners can be removed cleanly
- bind MobileManager handlers and remove all listeners, including double-tap prevention

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896ce32d33c83279c47cdf62a371d95