### PR TITLE
fix: preserve system manager in Game initialization

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -224,14 +224,18 @@ class Game {
 
     async initialize() {
         console.log('[Game] Initializing game systems...');
-        
+
         try {
-            // Initialize system manager
-            this.systemManager = new GameSystemManager();
-            const initResult = await this.systemManager.initialize();
-            
-            if (!initResult.success) {
-                throw new Error(`System initialization failed: ${initResult.error}`);
+            // Initialize system manager if needed
+            if (!this.systemManager) {
+                this.systemManager = new GameSystemManager();
+            }
+
+            if (!this.systemManager.initializationComplete && typeof this.systemManager.initialize === 'function') {
+                const initResult = await this.systemManager.initialize();
+                if (!initResult.success) {
+                    throw new Error(`System initialization failed: ${initResult.error}`);
+                }
             }
             
             // Setup input handling


### PR DESCRIPTION
## Summary
- prevent `Game.initialize` from overwriting the `systemManager` provided by `GameBootstrap`
- only create and initialize a `GameSystemManager` when one isn't supplied or hasn't run yet

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68971d1598bc8327882848761a9b2604