### PR TITLE
Make the game a complete, playable castle-defense loop

### DIFF
--- a/css/ui-screens.css
+++ b/css/ui-screens.css
@@ -2359,3 +2359,43 @@
         font-size: 1rem;
     }
 }
+
+/* ===== Level Select grid (populated by ScreenManager.populateLevelGrid) ===== */
+.level-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    justify-content: center;
+    margin: 24px 0;
+}
+
+.level-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-width: 150px;
+    min-height: 90px;
+    padding: 16px 20px;
+    cursor: pointer;
+    text-align: center;
+}
+
+.level-tile .level-number {
+    font-size: 0.85rem;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    opacity: 0.7;
+}
+
+.level-tile .level-name {
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
+.level-tile.selected {
+    outline: 2px solid #00d4ff;
+    box-shadow: 0 0 16px rgba(0, 212, 255, 0.6);
+    transform: translateY(-2px);
+}

--- a/js/ScreenManager.js
+++ b/js/ScreenManager.js
@@ -8,6 +8,15 @@ class ScreenManager {
         this.modalStack = [];
         this.callbacks = new Map();
 
+        // Campaign levels available in level select (names mirror
+        // LevelManager.levelConfig in js/level.js).
+        this.levelDefinitions = [
+            { id: 1, name: 'Meditation Garden' },
+            { id: 2, name: 'Temple Servers' },
+            { id: 3, name: 'Cyber Monastery' }
+        ];
+        this.selectedLevel = 1;
+
         this.setupScreens();
         this.setupEventListeners();
         this.hideAllScreens(); // Hide all screens initially
@@ -136,6 +145,24 @@ class ScreenManager {
         this.addClickListener('pause-game-btn', () => this.pauseGame());
         this.addClickListener('resume-game-btn', () => this.resumeGame());
         this.addClickListener('return-to-menu-btn', () => this.returnToMenu());
+
+        // Victory screen actions (show the game screen first so the canvas is
+        // active when the level's deferred resize fires)
+        this.addClickListener('nextLevelBtn', () => { this.showScreen('game'); this.triggerCallback('nextLevel'); });
+        this.addClickListener('replayLevelBtn', () => { this.showScreen('game'); this.triggerCallback('replayLevel'); });
+        this.addClickListener('backToMenuFromVictoryBtn', () => this.showScreen('main-menu'));
+
+        // Defeat screen actions
+        this.addClickListener('retryFromDefeatBtn', () => { this.showScreen('game'); this.triggerCallback('retryLevel'); });
+        this.addClickListener('selectLevelFromDefeatBtn', () => this.showScreen('level-select'));
+        this.addClickListener('backToMenuFromDefeatBtn', () => this.showScreen('main-menu'));
+
+        // Level select
+        this.addClickListener('playSelectedLevelBtn', () => this.playSelectedLevel());
+
+        // Surface the victory/defeat screen when a level run ends. game.js
+        // dispatches this CustomEvent from gameOver()/winLevel().
+        document.addEventListener('gameOver', (e) => this.handleGameOver(e.detail || {}));
 
         // Modal close buttons
         this.addClickListener('close-upgrade-tree', () => this.closeModal('upgrade-tree'));
@@ -819,8 +846,59 @@ class ScreenManager {
     }
 
     loadLevelInfo() {
-        // Load level selection data
+        // Build the level grid and let any listeners augment it (e.g. lock state)
+        this.populateLevelGrid();
         this.triggerCallback('loadLevelInfo');
+    }
+
+    populateLevelGrid() {
+        const grid = document.getElementById('levelGrid');
+        if (!grid) return;
+
+        grid.innerHTML = '';
+
+        this.levelDefinitions.forEach(level => {
+            const tile = document.createElement('button');
+            tile.className = 'level-tile btn secondary' + (level.id === this.selectedLevel ? ' selected' : '');
+            tile.setAttribute('data-level', String(level.id));
+            tile.innerHTML = `<span class="level-number">Level ${level.id}</span>` +
+                `<span class="level-name">${level.name}</span>`;
+            tile.addEventListener('click', () => this.selectLevel(level.id));
+            grid.appendChild(tile);
+        });
+    }
+
+    selectLevel(levelId) {
+        this.selectedLevel = levelId;
+        const tiles = document.querySelectorAll('#levelGrid .level-tile');
+        tiles.forEach(tile => {
+            tile.classList.toggle('selected', Number(tile.getAttribute('data-level')) === levelId);
+        });
+    }
+
+    playSelectedLevel() {
+        const level = this.selectedLevel || 1;
+        console.log(`[ScreenManager] Playing selected level: ${level}`);
+        this.showScreen('game');
+        this.triggerCallback('startLevel', { level });
+    }
+
+    handleGameOver(detail) {
+        const victory = !!detail.victory;
+        console.log(`[ScreenManager] gameOver received (victory=${victory})`);
+
+        if (victory) {
+            const scoreEl = document.getElementById('finalScore');
+            if (scoreEl) scoreEl.textContent = detail.score != null ? detail.score : 0;
+
+            // "Next Level" only makes sense when a further level exists.
+            const nextBtn = document.getElementById('nextLevelBtn');
+            if (nextBtn) nextBtn.style.display = detail.hasNextLevel ? '' : 'none';
+
+            this.showScreen('victory');
+        } else {
+            this.showScreen('defeat');
+        }
     }
 
     // Callback system

--- a/js/game.js
+++ b/js/game.js
@@ -28,8 +28,16 @@ class Game {
             level: 1,
             wave: 1,
             lives: 10,
-            score: 0
+            maxLives: 10,
+            score: 0,
+            ended: false
         };
+
+        // Number of campaign levels available (drives "Next Level" availability).
+        this.totalLevels = 3;
+
+        // Transient visual: counts down after the castle is hit (enemy escaped).
+        this.castleFlash = 0;
 
         // Resources
         this.resources = {
@@ -288,6 +296,18 @@ class Game {
         this.screenManager.on('resumeGame', () => this.resumeGame());
         this.screenManager.on('returnToMenu', () => this.returnToMenu());
 
+        // Victory / defeat / level-select screen actions
+        this.screenManager.on('nextLevel', () => {
+            this.startLevel(Math.min(this.gameState.level + 1, this.totalLevels));
+        });
+        this.screenManager.on('replayLevel', () => this.startLevel(this.gameState.level));
+        this.screenManager.on('retryLevel', () => this.startLevel(this.gameState.level));
+        this.screenManager.on('startLevel', (data) => {
+            const level = data && data.level ? data.level : 1;
+            this.gameState.score = 0;
+            this.startLevel(level);
+        });
+
         // Defense manager callbacks
         this.defenseManager.on('checkResources', (data) => this.checkResources(data.cost));
         this.defenseManager.on('deductResources', (data) => this.deductResources(data.cost));
@@ -450,16 +470,26 @@ class Game {
     // Game Flow Methods
     startNewGame() {
         console.log('[Game] Starting new game...');
+        // A brand-new campaign run resets the cumulative score; per-level state
+        // is handled by startLevel().
+        this.gameState.score = 0;
+        this.startLevel(1);
+    }
 
-        this.gameState = {
-            running: true,
-            paused: false,
-            gameSpeed: 1,
-            level: 1,
-            wave: 1,
-            lives: 10,
-            score: 0
-        };
+    // Begin (or restart) a specific campaign level. Used by New Game, the
+    // victory screen's "Next Level"/"Replay", the defeat screen's "Retry",
+    // and level select. Resets per-level state but preserves cumulative score.
+    startLevel(levelNumber) {
+        console.log(`[Game] Starting level ${levelNumber}...`);
+
+        this.gameState.running = true;
+        this.gameState.paused = false;
+        this.gameState.gameSpeed = 1;
+        this.gameState.level = levelNumber;
+        this.gameState.wave = 0;
+        this.gameState.lives = 10;
+        this.gameState.maxLives = 10;
+        this.gameState.ended = false;
 
         this.resources = {
             dharma: 250,
@@ -471,6 +501,7 @@ class Game {
         this.enemies.length = 0;
         this.projectiles.length = 0;
         this.effects.length = 0;
+        this.castleFlash = 0;
 
         // Reset managers
         this.defenseManager.clear();
@@ -480,7 +511,7 @@ class Game {
         // Initialize level
         const levelManager = this.systemManager.getLevelManager();
         if (levelManager) {
-            levelManager.initializeLevel(this.gameState.level);
+            levelManager.initializeLevel(levelNumber);
         }
 
         // Now that we're starting the game, enable and perform canvas resize
@@ -743,10 +774,8 @@ class Game {
             if (!enemy.isAlive) {
                 this.onEnemyDestroyed(enemy);
                 this.enemies.splice(i, 1);
-            }
-
-            // Check if enemy reached the end
-            if (enemy.reachedEnd) {
+            } else if (enemy.reachedEnd) {
+                // Check if enemy reached the end (only if it wasn't just removed)
                 this.onEnemyEscaped(enemy);
                 this.enemies.splice(i, 1);
             }
@@ -783,6 +812,7 @@ class Game {
         // Render game world
         this.renderBackground();
         this.renderPath();
+        this.renderCastle();
 
         this.renderEnemies();
         this.defenseManager.render(this.ctx);
@@ -957,6 +987,99 @@ class Game {
         this.ctx.restore();
     }
 
+    // The castle (temple/stupa) the player defends, drawn at the path's exit.
+    // Its health bar is tied directly to gameState.lives, so every enemy that
+    // escapes visibly damages the castle.
+    renderCastle() {
+        const levelManager = this.systemManager.getLevelManager();
+        if (!levelManager) return;
+
+        const path = levelManager.getCurrentPath();
+        if (!path || path.length < 1) return;
+
+        const end = path[path.length - 1];
+        const cx = end.x;
+        const cy = end.y;
+
+        const maxLives = this.gameState.maxLives || 10;
+        const healthPct = Math.max(0, Math.min(1, this.gameState.lives / maxLives));
+
+        // Tint shifts from serene cyan (healthy) toward warning red (near-breach).
+        const lerp = (a, b) => Math.round(a + (b - a) * (1 - healthPct));
+        const coreColor = `rgb(${lerp(0, 255)}, ${lerp(212, 68)}, ${lerp(255, 68)})`;
+
+        const ctx = this.ctx;
+        ctx.save();
+
+        // Damage flash (counts down per rendered frame after a breach).
+        const flashing = this.castleFlash > 0;
+        if (flashing) this.castleFlash--;
+
+        const baseWidth = 54;
+        const baseHeight = 16;
+        const bodyWidth = 40;
+        const bodyHeight = 30;
+
+        ctx.strokeStyle = coreColor;
+        ctx.lineWidth = 2;
+        ctx.shadowBlur = flashing ? 30 : 16;
+        ctx.shadowColor = flashing ? '#ff0000' : coreColor;
+
+        // Stepped temple base
+        ctx.fillStyle = '#0b1d2a';
+        ctx.beginPath();
+        ctx.rect(cx - baseWidth / 2, cy + bodyHeight / 2 - 2, baseWidth, baseHeight);
+        ctx.fill();
+        ctx.stroke();
+
+        // Temple body
+        ctx.beginPath();
+        ctx.rect(cx - bodyWidth / 2, cy - bodyHeight / 2, bodyWidth, bodyHeight);
+        ctx.fill();
+        ctx.stroke();
+
+        // Pagoda roof
+        ctx.shadowBlur = flashing ? 30 : 12;
+        ctx.fillStyle = '#10283a';
+        ctx.beginPath();
+        ctx.moveTo(cx, cy - bodyHeight / 2 - 22);
+        ctx.lineTo(cx - bodyWidth / 2 - 8, cy - bodyHeight / 2 + 2);
+        ctx.lineTo(cx + bodyWidth / 2 + 8, cy - bodyHeight / 2 + 2);
+        ctx.closePath();
+        ctx.fill();
+        ctx.stroke();
+
+        // Glowing dharma core
+        ctx.shadowBlur = flashing ? 24 : 14;
+        ctx.fillStyle = flashing ? '#ffffff' : coreColor;
+        ctx.beginPath();
+        ctx.arc(cx, cy, 7, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Health bar above the castle
+        ctx.shadowBlur = 0;
+        const barWidth = 56;
+        const barHeight = 6;
+        const barX = cx - barWidth / 2;
+        const barY = cy - bodyHeight / 2 - 40;
+
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        ctx.fillRect(barX - 1, barY - 1, barWidth + 2, barHeight + 2);
+        ctx.fillStyle = healthPct > 0.5 ? '#00ff88' : (healthPct > 0.25 ? '#ffd60a' : '#ff4444');
+        ctx.fillRect(barX, barY, barWidth * healthPct, barHeight);
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineWidth = 1;
+        ctx.strokeRect(barX, barY, barWidth, barHeight);
+
+        // Lives label
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '10px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText(`Castle ${this.gameState.lives}/${maxLives}`, cx, barY - 4);
+
+        ctx.restore();
+    }
+
     renderEnemies() {
         // Debug logging (rate limited)
         this.logDebug('Enemies rendered', { count: this.enemies.length }, 'performance');
@@ -1031,24 +1154,58 @@ class Game {
     }
 
     checkGameOver() {
+        // Only one terminal transition per level run.
+        if (!this.gameState.running || this.gameState.ended) return;
         if (this.gameState.lives <= 0) {
             this.gameOver(false);
         }
     }
 
-    gameOver(victory) {
+    // Player lost: the castle's lives reached zero. Dispatches the `gameOver`
+    // event that ScreenManager listens for to show the defeat screen.
+    gameOver(victory = false) {
+        if (this.gameState.ended) return;
+        this.gameState.ended = true;
         this.gameState.running = false;
 
         console.log(`[Game] Game Over - ${victory ? 'Victory' : 'Defeat'}`);
 
-        // Show game over screen
         const event = new CustomEvent('gameOver', {
-            detail: { victory, score: this.gameState.score }
+            detail: {
+                victory,
+                score: this.gameState.score,
+                level: this.gameState.level,
+                hasNextLevel: false
+            }
         });
         document.dispatchEvent(event);
 
-        // Track achievements
         this.trackGameOverAchievements(victory);
+    }
+
+    // Player won the current level (all waves cleared). Shows the victory
+    // screen; "Next Level" is offered only when a further campaign level exists.
+    winLevel(data) {
+        if (this.gameState.ended) return;
+        this.gameState.ended = true;
+        this.gameState.running = false;
+
+        const completedLevel = (data && data.level) || this.gameState.level;
+        const hasNextLevel = completedLevel < this.totalLevels;
+
+        console.log(`[Game] Level ${completedLevel} cleared (hasNextLevel=${hasNextLevel})`);
+
+        const event = new CustomEvent('gameOver', {
+            detail: {
+                victory: true,
+                score: this.gameState.score,
+                level: completedLevel,
+                hasNextLevel
+            }
+        });
+        document.dispatchEvent(event);
+
+        this.trackGameOverAchievements(true);
     }
 
     // Resource Management
@@ -1116,17 +1273,15 @@ class Game {
 
     onLevelComplete(data) {
         console.log(`[Game] Level ${data.level} completed`);
-        this.gameState.level = data.level + 1;
-
-        // Big reward for level completion
-        const reward = this.calculateLevelReward(data);
-        this.addResources(reward);
-
-        this.uiManager.showNotification(`Level ${data.level} Complete!`, 'success', 5000);
 
         if (this.systemManager.getAudioManager()) {
             this.systemManager.getAudioManager().playSound('level_complete');
         }
+
+        // Surface the victory screen. Advancing to the next level is driven by
+        // the screen's "Next Level" button (-> startLevel via the 'nextLevel'
+        // callback), so we intentionally do not mutate gameState.level here.
+        this.winLevel(data);
     }
 
     spawnEnemy(enemyData, spawnPoint, path) {
@@ -1263,8 +1418,9 @@ class Game {
     }
 
     onEnemyEscaped(enemy) {
-        // Enemy reached the end, lose life
+        // Enemy reached the end, the castle takes a hit and loses a life
         this.gameState.lives--;
+        this.castleFlash = 12;
 
         if (this.gameState.lives > 0) {
             this.uiManager.showNotification('Enemy escaped! Life lost.', 'warning');

--- a/js/level.js
+++ b/js/level.js
@@ -3,7 +3,9 @@ class LevelManager {
     constructor() {
         this.currentLevel = 1;
         this.currentWave = 1;
-        this.maxWaves = 20;
+        // 10 waves per level to match CONFIG.WAVES / MAX_WAVES and keep a level a
+        // reasonable, completable length. Boss waves fall on 5 and 10.
+        this.maxWaves = 10;
         this.waveInProgress = false;
         this.waveStartTime = 0;
         this.waveEndTime = 0;
@@ -507,9 +509,10 @@ class LevelManager {
 
         if (this.currentWave >= this.maxWaves) {
             this.completeLevel();
-        } else {
-            this.currentWave++;
         }
+        // Do NOT increment currentWave here: startWave() already advances the
+        // wave counter when the next wave begins. Incrementing in both places
+        // skipped every other wave (1, 3, 5, ...) and bypassed boss waves.
     }
 
     completeLevel() {

--- a/js/main.js
+++ b/js/main.js
@@ -252,7 +252,15 @@ class GameBootstrap {
     }
 }
 
+// Default export so the Vite entry shim (src/main.js) can import GameBootstrap.
+export default GameBootstrap;
+
 window.addEventListener('load', () => {
+    // Guard against double-bootstrapping. Under Vite, src/main.js triggers init
+    // on DOMContentLoaded; when served unbundled, this `load` handler runs. The
+    // shared flag ensures exactly one GameBootstrap is ever created.
+    if (window.__dharmapalaBootstrapped) return;
+    window.__dharmapalaBootstrapped = true;
     const bootstrap = new GameBootstrap();
     bootstrap.init().catch(err => {
         console.error('Bootstrap initialization failed', err);

--- a/js/sprite.js
+++ b/js/sprite.js
@@ -122,6 +122,37 @@ class SpriteManager {
     }
 
     getFallbackColor(name) {
+        // Type-specific colors so procedurally-generated fallback sprites stay
+        // visually distinct per enemy/boss/defense type (these match the colors
+        // defined in CONFIG so a fallback reads like the intended unit). This is
+        // what keeps enemies such as quantumHacker/corruptedMonk/raidTeam/megaCorp
+        // recognizable even when their PNG art is missing.
+        const typeColors = {
+            // Enemies
+            scriptKiddie: '#ff7675',
+            federalAgent: '#2d3436',
+            corporateSaboteur: '#636e72',
+            aiSurveillance: '#74b9ff',
+            quantumHacker: '#00b894',
+            corruptedMonk: '#6c5ce7',
+            raidTeam: '#e17055',
+            megaCorp: '#fd79a8',
+            // Defenses
+            firewall: '#ff6b6b',
+            encryption: '#4ecdc4',
+            decoy: '#45b7d1',
+            mirror: '#f9ca24',
+            anonymity: '#6c5ce7',
+            dharma: '#ffd700'
+        };
+
+        // Extract the type token from names like `enemy_quantumHacker`,
+        // `boss_megaCorp_phase1`, or `defense_firewall_level1`.
+        const typeToken = name.split('_')[1];
+        if (typeToken && typeColors[typeToken]) {
+            return typeColors[typeToken];
+        }
+
         if (name.includes('boss')) return '#ff0080';
         if (name.includes('defense') || name.includes('tower')) return '#00d4ff';
         if (name.includes('enemy')) return '#ff6b35';

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,10 @@
 import GameBootstrap from '../js/main.js';
 
 window.addEventListener('DOMContentLoaded', () => {
+  // Guard against double-bootstrapping (see js/main.js). Whichever entry fires
+  // first wins; the other becomes a no-op.
+  if (window.__dharmapalaBootstrapped) return;
+  window.__dharmapalaBootstrapped = true;
   const bootstrap = new GameBootstrap();
   bootstrap.init();
 });


### PR DESCRIPTION
Wire the missing seams that prevented a full start-to-finish playthrough,
add a real castle the player defends, and fix several correctness bugs.

Game-over / win flow (the critical blocker):
- game.js dispatched a `gameOver` CustomEvent that nothing listened for, so
  winning or losing froze the screen with no result and no way out.
  ScreenManager now listens for `gameOver` and shows the victory/defeat
  screen, populating the final score and toggling "Next Level" by availability.
- Wired every victory/defeat button (Next Level, Replay, Retry, Level Select,
  Main Menu) and the Level Select "Play Level" button, which had no handlers.
- Added winLevel() for level completion and guarded gameOver()/checkGameOver()
  with an `ended` flag so a run has exactly one terminal transition.

Level progression:
- onLevelComplete() previously bumped the level counter but left LevelManager
  stranded, so the player could never get past level 1. Refactored
  startNewGame() into a reusable startLevel(n) used by New Game, Next Level,
  Replay, Retry, and Level Select.
- Level Select now populates a clickable level grid with a selected state.

Castle entity:
- Added renderCastle(): a temple/stupa drawn at the path exit with a health
  bar tied directly to lives, tinting cyan->red as the castle is breached and
  flashing on each hit. The lives counter is now a visible castle you defend.

Bug fixes:
- LevelManager.completeWave() double-incremented the wave counter (startWave()
  also increments), which skipped every other wave and bypassed boss waves.
- maxWaves 20 -> 10 to match CONFIG.WAVES / documented MAX_WAVES and keep a
  level a completable length (bosses on waves 5 and 10).
- js/main.js never exported GameBootstrap, so the Vite entry (src/main.js)
  failed to import it and the documented dev/build workflow was broken. Added
  the default export plus a shared guard so the two entry points can't
  double-bootstrap.
- Hardened the enemy-removal loop (else-if) so a removed enemy can't be
  spliced twice.

Visuals:
- Type-aware procedural fallback sprites so enemies/bosses without PNG art
  (quantumHacker, corruptedMonk, raidTeam, megaCorp) render in their distinct
  CONFIG colors instead of identical orange squares.
- Minimal CSS for the level-select grid/tiles.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xttb2cqLBQJxwTAMXnkpUa